### PR TITLE
Added support for track_scripts to the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install, enable and configure the keepalived VRRP and LVS management daemon.
 
 The configuration file to be used can be specificed using either the `$content`
 parameter (typically for templates), or the `$source` parameter. If neither is
-specified, you will need to manage it rom elsewhere.
+specified, you will need to manage it from elsewhere.
 
 See the `templates/sysconfig.erb` file for the possible `$options` values. The
 default is `-D` which enables both VRRP and LVS.

--- a/templates/keepalived-vrrp.conf.erb
+++ b/templates/keepalived-vrrp.conf.erb
@@ -20,9 +20,36 @@ global_defs {
  <%- end -%>
 }
 <%- @instances.sort_by {|iname,idata| iname}.each do |iname,idata| -%>
+<%- if idata['track_script'] -%>
+<%- idata['track_script'].each do |key, value| %>
+vrrp_script <%= File.basename(value['script'], '.sh') %> {
+  <%- if value['script'] -%>
+  script "<%= value['script'] %>"
+  <%- end -%>
+  <%- if value['interval'] -%>
+  interval <%= value['interval'] %>
+  <%- end -%>
+  <%- if value['weight'] -%>
+  weight <%= value['weight'] %>
+  <%- end -%>
+  <%- if value['timeout'] -%>
+  timeout <%= value['timeout'] %>
+  <%- end -%>
+  <%- if value['rise'] -%>
+  rise <%= value['rise'] %>
+  <%- end -%>
+  <%- if value['fall'] -%>
+  fall <%= value['fall'] %>
+  <%- end -%>
+  <%- if value['user'] -%>
+  user <%= value['user'] %>
+  <%- end -%>
+}
+<%- end -%>
+<%- end -%>
 
 vrrp_instance <%= iname %> {
- <%- idata.sort_by {|key,value| key}.each do |key,value| -%>
+<%- idata.select{|k,v| !['track_script'].include?(k)}.sort_by {|key,value| key}.each do |key,value| -%>
   <%- if value.is_a?(Hash) -%>
   <%= key %> {
    <%- value.sort_by {|k,v| k}.each do |k,v| -%>
@@ -39,5 +66,12 @@ vrrp_instance <%= iname %> {
   <%= key %> <%= value %>
   <%- end -%>
  <%- end -%>
+ <%- if idata['track_script'] -%>
+ <%- idata['track_script'].each do |key, value| %>
+  track_script {
+   <%= File.basename(value['script'], '.sh') %> 
+ }
+ <%- end -%>
+ <%- end -%>
 }
-<% end -%>
+<%- end -%>


### PR DESCRIPTION
This PR adds support for track_scripts in the keepalived Puppet module template.

With this new feature, users can now define scripts to be tracked by keepalived and have the virtual IP failover if the script fails. This is useful for monitoring services that are critical for the proper functioning of the virtual IP, such as database or load balancer services.

The changes made include:

    Adding a new section to the template that loops through the instances and their associated track_scripts, generating a vrrp_script block for each track_script defined in the instance.
    Modifying the vrrp_instance section to include a new track_script block for each instance that has track_scripts defined.
    Updating the README.md file to document the new feature.

These changes have been tested locally and the new feature is working as expected.