### PR TITLE
Pass the $instance variable to the ERB template

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,9 +29,15 @@ class keepalived (
   $service_hasstatus = $::keepalived::params::service_hasstatus,
   $service_restart   = $::keepalived::params::service_restart,
   $package_ensure    = 'installed',
+  Optional[Array[String]] $package_install_options = undef,
+  Optional[Variant[Hash, Array[Hash]]] $instances = [],
+
 ) inherits ::keepalived::params {
 
-  package { $package: ensure => $package_ensure }
+  package { $package: 
+    ensure => $package_ensure,
+    install_options => $package_install_options,
+  }
 
   service { $service:
     ensure    => $service_ensure,

--- a/manifests/vrrp.pp
+++ b/manifests/vrrp.pp
@@ -16,12 +16,14 @@ class keepalived::vrrp (
 ) {
 
   $global_defs_final = merge($global_defs_defaults,$global_defs)
-
+  $instances_normalized = $instances =~ Hash ? $instances.values : $instances
+  
   class { '::keepalived':
     service_ensure => $service_ensure,
     service_enable => $service_enable,
     content        => template("${template_module}${template_dir}${template}"),
     options        => '-D --vrrp',
+    instances      => $instances_normalized,
   }
 
 }


### PR DESCRIPTION
And integrate the changes by yoricps  https://github.com/thias/puppet-keepalived/pull/6/commits

In vrrp.pp the parameter $instances is declared , but not usied or passed to the template.
So @instances ends up as nil in the ERB context.